### PR TITLE
Fix wandb monitor gym

### DIFF
--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -367,6 +367,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -319,6 +319,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -317,6 +317,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -435,6 +435,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -484,6 +484,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -421,6 +421,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -395,6 +395,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -30,7 +30,7 @@ def get_space_shape(env_space: gym.Space) -> tuple[int, ...]:
 
 
 class ReplayBuffer:
-    @dataclasses.dataclass
+    @dataclasses.dataclass(frozen=True)
     class Samples(Generic[SamplesItemType]):
         observations: SamplesItemType
         actions: SamplesItemType
@@ -356,6 +356,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,

--- a/abcdrl_copy_from/wrapper_logger.py
+++ b/abcdrl_copy_from/wrapper_logger.py
@@ -19,6 +19,11 @@ def wrapper_logger(
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
         if track:
+            import gym as gym_
+
+            gym_.wrappers.monitoring.video_recorder.ImageEncoder = (  # type: ignore[attr-defined]
+                gym_.wrappers.monitoring.video_recorder.VideoRecorder
+            )
             wandb.init(
                 project=wandb_project_name,
                 tags=wandb_tags,


### PR DESCRIPTION
# Description

wandb does not support gym0.26 yet, and a [Wandb PR 4363](https://github.com/wandb/wandb/pull/4363) has been working to fix this issue.

This PR temporarily fixes this bug. Wait for [Wandb PR 4363](https://github.com/wandb/wandb/pull/4363) to merge before we revert to the previous code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
