### PR TITLE
Fix replaybuffer random replace

### DIFF
--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -72,7 +72,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -72,7 +72,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -72,7 +72,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -72,7 +72,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -72,7 +72,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -73,7 +73,7 @@ class ReplayBuffer:
             self.size = min(self.size + 1, self.buffer_size)
 
     def sample(self, batch_size: int = 1) -> Samples[np.ndarray]:
-        idxs = np.random.choice(self.size, size=batch_size, replace=False)
+        idxs = np.random.choice(self.size, size=batch_size, replace=True)
         return ReplayBuffer.Samples[np.ndarray](
             observations=self.obs_buf[idxs],
             next_observations=self.next_obs_buf[idxs],


### PR DESCRIPTION
# Description

`idxs = np.random.choice(self.size, size=batch_size, replace=False)` in `ReplayBuffer` will make it very slow and results in poor performance. Change it to `idxs = np.random.choice(self.size, size=batch_size, replace=True)`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
