### PR TITLE
Fix env seed and exp_name

### DIFF
--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -286,7 +286,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -335,6 +335,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -267,10 +267,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["policy_frequency"] = max(
             self.kwargs["policy_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -376,7 +373,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -286,7 +286,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -337,11 +337,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -364,6 +364,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -371,12 +372,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -286,7 +286,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -335,8 +335,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -286,7 +286,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -245,7 +245,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -245,7 +245,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -295,11 +295,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -245,7 +245,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -293,8 +293,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -245,7 +245,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -293,6 +293,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -226,10 +226,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["target_network_frequency"] = max(
             self.kwargs["target_network_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -334,7 +331,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -322,6 +322,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -329,12 +330,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -243,7 +243,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -293,11 +293,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -224,10 +224,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["target_network_frequency"] = max(
             self.kwargs["target_network_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -332,7 +329,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -243,7 +243,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -291,8 +291,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -243,7 +243,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -243,7 +243,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -291,6 +291,11 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -291,6 +291,8 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
 
             env.reset_ = env.reset
             env.reset = lambda **kwargs: env.reset_(

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -325,6 +325,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -332,12 +333,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -352,7 +352,7 @@ class Trainer:
             optimize_memory_usage=True,
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -352,7 +352,7 @@ class Trainer:
             optimize_memory_usage=True,
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -412,9 +412,6 @@ class Trainer:
             env = gym.wrappers.ResizeObservation(env, (84, 84))
             env = gym.wrappers.GrayScaleObservation(env)
             env = gym.wrappers.FrameStack(env, 4)
-
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -352,7 +352,7 @@ class Trainer:
             optimize_memory_usage=True,
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -412,6 +412,13 @@ class Trainer:
             env = gym.wrappers.ResizeObservation(env, (84, 84))
             env = gym.wrappers.GrayScaleObservation(env)
             env = gym.wrappers.FrameStack(env, 4)
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -332,10 +332,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["target_network_frequency"] = max(
             self.kwargs["target_network_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -454,7 +451,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -352,7 +352,7 @@ class Trainer:
             optimize_memory_usage=True,
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -414,11 +414,6 @@ class Trainer:
             env = gym.wrappers.FrameStack(env, 4)
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -441,6 +441,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -448,12 +449,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -357,7 +357,7 @@ class Trainer:
             alpha=self.kwargs["alpha"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -409,6 +409,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -357,7 +357,7 @@ class Trainer:
             alpha=self.kwargs["alpha"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -409,8 +409,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -357,7 +357,7 @@ class Trainer:
             alpha=self.kwargs["alpha"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -438,6 +438,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -445,12 +446,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -357,7 +357,7 @@ class Trainer:
             alpha=self.kwargs["alpha"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -411,11 +411,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -337,10 +337,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["target_network_frequency"] = max(
             self.kwargs["target_network_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -450,7 +447,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -394,7 +394,7 @@ class Trainer:
             gamma=self.kwargs["gamma"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.terminated = np.zeros((self.kwargs["num_envs"],), dtype=np.float32)
 
         self.agent = Agent(**self.kwargs)

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -394,7 +394,7 @@ class Trainer:
             gamma=self.kwargs["gamma"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.terminated = np.zeros((self.kwargs["num_envs"],), dtype=np.float32)
 
         self.agent = Agent(**self.kwargs)
@@ -461,6 +461,11 @@ class Trainer:
             env = gym.wrappers.TransformObservation(env, lambda obs: np.clip(obs, -10, 10))
             env = gym.wrappers.NormalizeReward(env, gamma=self.kwargs["gamma"])
             env = gym.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -461,6 +461,8 @@ class Trainer:
             env = gym.wrappers.TransformObservation(env, lambda obs: np.clip(obs, -10, 10))
             env = gym.wrappers.NormalizeReward(env, gamma=self.kwargs["gamma"])
             env = gym.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
 
             env.reset_ = env.reset
             env.reset = lambda **kwargs: env.reset_(

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -495,6 +495,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -502,12 +503,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -373,10 +373,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["batch_size"] = self.kwargs["num_envs"] * self.kwargs["num_steps"]
         self.kwargs["minibatch_size"] = self.kwargs["batch_size"] // self.kwargs["num_minibatches"]
         if self.kwargs["device"] == "auto":
@@ -502,7 +499,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -394,7 +394,7 @@ class Trainer:
             gamma=self.kwargs["gamma"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.terminated = np.zeros((self.kwargs["num_envs"],), dtype=np.float32)
 
         self.agent = Agent(**self.kwargs)
@@ -463,11 +463,6 @@ class Trainer:
             env = gym.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -394,7 +394,7 @@ class Trainer:
             gamma=self.kwargs["gamma"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.terminated = np.zeros((self.kwargs["num_envs"],), dtype=np.float32)
 
         self.agent = Agent(**self.kwargs)
@@ -461,8 +461,6 @@ class Trainer:
             env = gym.wrappers.TransformObservation(env, lambda obs: np.clip(obs, -10, 10))
             env = gym.wrappers.NormalizeReward(env, gamma=self.kwargs["gamma"])
             env = gym.wrappers.TransformReward(env, lambda reward: np.clip(reward, -10, 10))
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -345,7 +345,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -396,11 +396,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -345,7 +345,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -394,8 +394,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -323,10 +323,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["policy_frequency"] = max(
             self.kwargs["policy_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -435,7 +432,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -345,7 +345,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -394,6 +394,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -345,7 +345,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -423,6 +423,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -430,12 +431,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -314,7 +314,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -363,6 +363,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -314,7 +314,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -365,11 +365,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -392,6 +392,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -399,12 +400,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -314,7 +314,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -314,7 +314,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -363,8 +363,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -295,10 +295,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["policy_frequency"] = max(
             self.kwargs["policy_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -404,7 +401,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -244,7 +244,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset()
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -294,11 +294,6 @@ class Trainer:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
             env.action_space.seed(self.kwargs["seed"] + idx)
             env.observation_space.seed(self.kwargs["seed"] + idx)
-
-            env.reset_ = env.reset
-            env.reset = lambda **kwargs: env.reset_(
-                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
-            )
             return env
 
         return thunk

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -244,7 +244,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["num_envs"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=self.kwargs["seed"])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -359,6 +359,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -366,12 +367,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -244,7 +244,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset()
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -292,6 +292,13 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
+            env.action_space.seed(self.kwargs["seed"] + idx)
+            env.observation_space.seed(self.kwargs["seed"] + idx)
+
+            env.reset_ = env.reset
+            env.reset = lambda **kwargs: env.reset_(
+                **kwargs if "seed" in kwargs.keys() else {**kwargs, "seed": self.kwargs["seed"] + idx}
+            )
             return env
 
         return thunk

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -244,7 +244,7 @@ class Trainer:
             buffer_size=self.kwargs["buffer_size"],
         )
 
-        self.obs, _ = self.envs.reset(seed=[seed for seed in range(self.kwargs["num_envs"])])
+        self.obs, _ = self.envs.reset(seed=[self.kwargs["seed"] + idx for idx in range(self.kwargs["num_envs"])])
         self.agent = Agent(**self.kwargs)
 
     def __call__(self) -> Generator[dict[str, Any], None, None]:
@@ -292,8 +292,6 @@ class Trainer:
             if self.kwargs["capture_video"]:
                 if idx == 0:
                     env = gym.wrappers.RecordVideo(env, f"videos/{self.kwargs['exp_name']}")
-            env.action_space.seed(self.kwargs["seed"])
-            env.observation_space.seed(self.kwargs["seed"])
             return env
 
         return thunk

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -225,10 +225,7 @@ class Trainer:
         self.kwargs.pop("self")
 
         if self.kwargs["exp_name"] is None:
-            self.kwargs["exp_name"] = (
-                f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}__"
-                + f"{self.kwargs['seed']}__{int(time.time())}"
-            )
+            self.kwargs["exp_name"] = f"{self.kwargs['env_id']}__{os.path.basename(__file__).rstrip('.py')}"
         self.kwargs["target_network_frequency"] = max(
             self.kwargs["target_network_frequency"] // self.kwargs["num_envs"] * self.kwargs["num_envs"], 1
         )
@@ -371,7 +368,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl_copy_from/wrapper_logger.py
+++ b/abcdrl_copy_from/wrapper_logger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import Any, Callable, Generator
 
 import gymnasium as gym
@@ -38,7 +39,7 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"],
+                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
                 save_code=True,
             )
             setup_video_monitor()

--- a/abcdrl_copy_from/wrapper_logger.py
+++ b/abcdrl_copy_from/wrapper_logger.py
@@ -32,6 +32,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
                 project=wandb_project_name,
@@ -39,12 +40,12 @@ def wrapper_logger(
                 entity=wandb_entity,
                 sync_tensorboard=True,
                 config=instance.kwargs,
-                name=instance.kwargs["exp_name"] + f"__{instance.kwargs['seed']}__{int(time.time())}",
+                name=exp_name_,
                 save_code=True,
             )
             setup_video_monitor()
 
-        writer = SummaryWriter(f"runs/{instance.kwargs['exp_name']}")
+        writer = SummaryWriter(f"runs/{exp_name_}")
         writer.add_text(
             "hyperparameters",
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),


### PR DESCRIPTION
# Description

- The current random seed is only added in act and obs, but not the random seed required to set the parameters at reset.
- The current exp_name contains seed and timestamp, which is not convenient to grouping in wandb.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
