### PR TITLE
Fix __call__ signatures

### DIFF
--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -358,8 +359,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -367,6 +368,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -386,7 +388,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/ddpg.py
+++ b/abcdrl/ddpg.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/ddqn.py
+++ b/abcdrl/ddqn.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -316,8 +317,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -325,6 +326,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -344,7 +346,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/dqn.py
+++ b/abcdrl/dqn.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -314,8 +315,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -323,6 +324,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -342,7 +344,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/dqn_atari.py
+++ b/abcdrl/dqn_atari.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -435,8 +436,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -444,6 +445,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -463,7 +465,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -432,8 +433,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -441,6 +442,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -460,7 +462,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/pdqn.py
+++ b/abcdrl/pdqn.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.distributions.normal import Normal
 from torch.utils.tensorboard import SummaryWriter
 

--- a/abcdrl/ppo.py
+++ b/abcdrl/ppo.py
@@ -13,6 +13,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.distributions.normal import Normal
 from torch.utils.tensorboard import SummaryWriter
 
@@ -484,8 +485,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -493,6 +494,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -512,7 +514,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl/sac.py
+++ b/abcdrl/sac.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -417,8 +418,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -426,6 +427,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -445,7 +447,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -386,8 +387,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -395,6 +396,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -414,7 +416,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl/td3.py
+++ b/abcdrl/td3.py
@@ -15,7 +15,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)

--- a/abcdrl_copy_from/dqn_all_wrappers.py
+++ b/abcdrl_copy_from/dqn_all_wrappers.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 SamplesItemType = TypeVar("SamplesItemType", torch.Tensor, np.ndarray)
@@ -303,19 +304,20 @@ class Trainer:
 def wrapper_eval_step(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         eval_frequency: int = 5_000,
         num_steps_eval: int = 500,
         eval_env_seed: int = 1,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         eval_frequency = max(eval_frequency // instance.kwargs["num_envs"] * instance.kwargs["num_envs"], 1)
         eval_env = gym.vector.SyncVectorEnv([instance._make_env(eval_env_seed)])  # type: ignore[arg-type]
         eval_obs, _ = eval_env.reset(seed=1)
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if not log_data["sample_step"] % eval_frequency and log_data["log_type"] == "collect":
                 el_list, er_list = [], []
@@ -353,8 +355,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -362,6 +364,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -381,7 +384,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():
@@ -394,10 +397,12 @@ def wrapper_logger(
 def wrapper_save_model(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
-    def _wrapper(instance, *args, save_frequency: int = 1_000_0, **kwargs) -> Generator[dict[str, Any], None, None]:
+    @combine_signatures(wrapped)
+    def _wrapper(*args, save_frequency: int = 1_000_0, **kwargs) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         save_frequency = max(save_frequency // instance.kwargs["num_envs"] * instance.kwargs["num_envs"], 1)
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if not log_data["sample_step"] % save_frequency:
                 if not os.path.exists(f"models/{instance.kwargs['exp_name']}"):
@@ -412,8 +417,9 @@ def wrapper_save_model(
 def wrapper_print_filter(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
-    def _wrapper(instance, *args, **kwargs) -> Generator[dict[str, Any], None, None]:
-        gen = wrapped(instance, *args, **kwargs)
+    @combine_signatures(wrapped)
+    def _wrapper(*args, **kwargs) -> Generator[dict[str, Any], None, None]:
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data and log_data["log_type"] != "train":
                 yield log_data

--- a/abcdrl_copy_from/wrapper_eval_step.py
+++ b/abcdrl_copy_from/wrapper_eval_step.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable, Generator
 
 import gymnasium as gym
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 
 
 def wrapper_eval_step(

--- a/abcdrl_copy_from/wrapper_eval_step.py
+++ b/abcdrl_copy_from/wrapper_eval_step.py
@@ -3,24 +3,26 @@ from __future__ import annotations
 from typing import Any, Callable, Generator
 
 import gymnasium as gym
+from terminedia.utils import combine_signatures
 
 
 def wrapper_eval_step(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         eval_frequency: int = 5_000,
         num_steps_eval: int = 500,
         eval_env_seed: int = 1,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         eval_frequency = max(eval_frequency // instance.kwargs["num_envs"] * instance.kwargs["num_envs"], 1)
         eval_env = gym.vector.SyncVectorEnv([instance._make_env(eval_env_seed)])  # type: ignore[arg-type]
         eval_obs, _ = eval_env.reset(seed=1)
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if not log_data["sample_step"] % eval_frequency and log_data["log_type"] == "collect":
                 el_list, er_list = [], []

--- a/abcdrl_copy_from/wrapper_logger.py
+++ b/abcdrl_copy_from/wrapper_logger.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Generator
 
 import gymnasium as gym
 import wandb
+from terminedia.utils import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 
@@ -23,8 +24,8 @@ def wrapper_logger(
 
         vcr.close = close
 
+    @combine_signatures(wrapped)
     def _wrapper(
-        instance,
         *args,
         track: bool = False,
         wandb_project_name: str = "abcdrl",
@@ -32,6 +33,7 @@ def wrapper_logger(
         wandb_entity: str | None = None,
         **kwargs,
     ) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         exp_name_ = f"{instance.kwargs['exp_name']}__{instance.kwargs['seed']}__{int(time.time())}"
         if track:
             wandb.init(
@@ -51,7 +53,7 @@ def wrapper_logger(
             "|param|value|\n|-|-|\n" + "\n".join([f"|{key}|{value}|" for key, value in instance.kwargs.items()]),
         )
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data:
                 for log_item in log_data["logs"].items():

--- a/abcdrl_copy_from/wrapper_logger.py
+++ b/abcdrl_copy_from/wrapper_logger.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Generator
 
 import gymnasium as gym
 import wandb
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 from torch.utils.tensorboard import SummaryWriter
 
 

--- a/abcdrl_copy_from/wrapper_print_filter.py
+++ b/abcdrl_copy_from/wrapper_print_filter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Generator
 
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 
 
 def wrapper_print_filter(

--- a/abcdrl_copy_from/wrapper_print_filter.py
+++ b/abcdrl_copy_from/wrapper_print_filter.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Callable, Generator
 
+from terminedia.utils import combine_signatures
+
 
 def wrapper_print_filter(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
-    def _wrapper(instance, *args, **kwargs) -> Generator[dict[str, Any], None, None]:
-        gen = wrapped(instance, *args, **kwargs)
+    @combine_signatures(wrapped)
+    def _wrapper(*args, **kwargs) -> Generator[dict[str, Any], None, None]:
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if "logs" in log_data and log_data["log_type"] != "train":
                 yield log_data

--- a/abcdrl_copy_from/wrapper_save_model.py
+++ b/abcdrl_copy_from/wrapper_save_model.py
@@ -4,15 +4,18 @@ import os
 from typing import Any, Callable, Generator
 
 import dill
+from terminedia.utils import combine_signatures
 
 
 def wrapper_save_model(
     wrapped: Callable[..., Generator[dict[str, Any], None, None]]
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
-    def _wrapper(instance, *args, save_frequency: int = 1_000_0, **kwargs) -> Generator[dict[str, Any], None, None]:
+    @combine_signatures(wrapped)
+    def _wrapper(*args, save_frequency: int = 1_000_0, **kwargs) -> Generator[dict[str, Any], None, None]:
+        instance = args[0]
         save_frequency = max(save_frequency // instance.kwargs["num_envs"] * instance.kwargs["num_envs"], 1)
 
-        gen = wrapped(instance, *args, **kwargs)
+        gen = wrapped(*args, **kwargs)
         for log_data in gen:
             if not log_data["sample_step"] % save_frequency:
                 if not os.path.exists(f"models/{instance.kwargs['exp_name']}"):

--- a/abcdrl_copy_from/wrapper_save_model.py
+++ b/abcdrl_copy_from/wrapper_save_model.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, Callable, Generator
 
 import dill
-from terminedia.utils import combine_signatures
+from combine_signatures.combine_signatures import combine_signatures
 
 
 def wrapper_save_model(

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,6 +6,7 @@ free-mujoco-py==2.1.6
 wandb==0.13.6
 fire==0.5.0
 dill==0.3.6
+terminedia==0.4.2
 
 pre-commit==2.20.0
 pytest==7.0.1

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,7 +6,7 @@ free-mujoco-py==2.1.6
 wandb==0.13.6
 fire==0.5.0
 dill==0.3.6
-terminedia==0.4.2
+combine_signatures==0.1.0
 
 pre-commit==2.20.0
 pytest==7.0.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,3 +6,4 @@ free-mujoco-py==2.1.6
 wandb==0.13.6
 fire==0.5.0
 dill==0.3.6
+terminedia==0.4.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,4 +6,4 @@ free-mujoco-py==2.1.6
 wandb==0.13.6
 fire==0.5.0
 dill==0.3.6
-terminedia==0.4.2
+combine_signatures==0.1.0


### PR DESCRIPTION
# Description

The `--help` argument of google-fire is currently unavailable for the `__call__` function because it is wrapped.

Fixing this bug requires combining the signatures of the two functions at wrapper time.

Ref: [jsbueno/terminedia](https://github.com/jsbueno/terminedia/blob/62b1c307e5f276e7eb5d56dacc35a326fb424481/terminedia/utils/__init__.py#L83) and [stackoverflow question](https://stackoverflow.com/questions/34402773/signature-changing-decorator-properly-documenting-additional-argument)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have updated the documentation and previewed the changes via `mkdocs serve`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
